### PR TITLE
Migrate deprecated properties to spring-boot-2 schema

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <java.version>1.8</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spring.boot.version>2.1.9.RELEASE</spring.boot.version>
+        <spring.boot.version>2.1.8.RELEASE</spring.boot.version>
 
         <start-class>com.odysseusinc.arachne.executionengine.ExecutionEngineStarter</start-class>
 
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.1.9.RELEASE</version>
+        <version>2.1.8.RELEASE</version>
         <relativePath/>
     </parent>
 

--- a/src/main/resources/application-base.yml
+++ b/src/main/resources/application-base.yml
@@ -16,10 +16,12 @@ logging:
     count:
       enabled: false
 spring:
-  http:
+  jmx:
+    unique-names: true
+  servlet:
     multipart:
-      max-request-size: 256MB
       max-file-size: 256MB
+      max-request-size: 256MB
 
 executor:
   corePoolSize: 4
@@ -47,15 +49,16 @@ swagger:
 csv:
   separator: ','
 
-endpoints:
-  jolokia:
-    enabled: true
-    path: /jolokia
-  jmx:
-    unique-names: true
-
 management:
-  port: 9999
+  endpoint:
+    jolokia:
+      enabled: true
+  server:
+    port: 9999
+  endpoints:
+    web:
+      path-mapping:
+        jolokia: /jolokia
 
 runtimeservice:
   dist:


### PR DESCRIPTION
Fix tomcat 9.0.26 packed into spring boot 2.1.9 is have a bug with SSL support, rolling back to 2.1.8 to stable tomcat 9.0.25 - failing after spring boot 2 migration