### PR TITLE
Add retry when result callback has failed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,6 +165,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.retry</groupId>
+            <artifactId>spring-retry</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.odysseusinc</groupId>
             <artifactId>data-source-manager</artifactId>
             <version>${arachne.commons.version}</version>

--- a/src/main/java/com/odysseusinc/arachne/executionengine/config/CallbackRetryConfig.java
+++ b/src/main/java/com/odysseusinc/arachne/executionengine/config/CallbackRetryConfig.java
@@ -1,0 +1,38 @@
+package com.odysseusinc.arachne.executionengine.config;
+
+import com.odysseusinc.arachne.executionengine.config.properties.CallbackRetryProperties;
+import com.odysseusinc.arachne.executionengine.service.LoggingRetryListener;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.support.RetryTemplate;
+import org.springframework.retry.support.RetryTemplateBuilder;
+import org.springframework.web.client.RestClientException;
+
+@Configuration
+@EnableConfigurationProperties(CallbackRetryProperties.class)
+public class CallbackRetryConfig {
+
+    @Bean
+    public RetryTemplate successCallbackRetryTemplate(CallbackRetryProperties properties) {
+        return buildRetryTemplate(properties.getSuccess());
+    }
+
+    @Bean
+    public RetryTemplate failureCallbackRetryTemplate(CallbackRetryProperties properties) {
+        return buildRetryTemplate(properties.getFailure());
+    }
+
+    private RetryTemplate buildRetryTemplate(CallbackRetryProperties.RetryPolicyProperties properties) {
+        CallbackRetryProperties.ExponentialBackoffPolicyProperties backoffPolicyProperties = properties.getBackoffPolicy();
+        RetryTemplateBuilder builder = RetryTemplate.builder()
+                .maxAttempts(properties.getMaxAttempts())
+                .exponentialBackoff(backoffPolicyProperties.getInitialIntervalMs(),
+                        backoffPolicyProperties.getMultiplier(),
+                        backoffPolicyProperties.getMaxIntervalMs())
+                .withListener(new LoggingRetryListener())
+                .retryOn(RestClientException.class)
+                .traversingCauses();
+        return builder.build();
+    }
+}

--- a/src/main/java/com/odysseusinc/arachne/executionengine/config/properties/CallbackRetryProperties.java
+++ b/src/main/java/com/odysseusinc/arachne/executionengine/config/properties/CallbackRetryProperties.java
@@ -1,0 +1,82 @@
+package com.odysseusinc.arachne.executionengine.config.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+
+@ConfigurationProperties(prefix = "callback.retry")
+public class CallbackRetryProperties {
+
+    private RetryPolicyProperties success = new RetryPolicyProperties();
+    private RetryPolicyProperties failure = new RetryPolicyProperties();
+
+    public RetryPolicyProperties getSuccess() {
+        return success;
+    }
+
+    public void setSuccess(RetryPolicyProperties success) {
+        this.success = success;
+    }
+
+    public RetryPolicyProperties getFailure() {
+        return failure;
+    }
+
+    public void setFailure(RetryPolicyProperties failure) {
+        this.failure = failure;
+    }
+
+    public static class RetryPolicyProperties {
+        @Min(1)
+        @Max(Integer.MAX_VALUE)
+        private int maxAttempts = 10;
+        private ExponentialBackoffPolicyProperties backoffPolicy = new ExponentialBackoffPolicyProperties();
+
+        public ExponentialBackoffPolicyProperties getBackoffPolicy() {
+            return backoffPolicy;
+        }
+
+        public void setBackoffPolicy(ExponentialBackoffPolicyProperties backoffPolicy) {
+            this.backoffPolicy = backoffPolicy;
+        }
+
+        public int getMaxAttempts() {
+            return maxAttempts;
+        }
+
+        public void setMaxAttempts(int maxAttempts) {
+            this.maxAttempts = maxAttempts;
+        }
+    }
+
+    public static class ExponentialBackoffPolicyProperties {
+        private long initialIntervalMs = 5_000L; //5s
+        private double multiplier = Math.E;
+        private long maxIntervalMs = 900_000L; //15min
+
+        public long getInitialIntervalMs() {
+            return initialIntervalMs;
+        }
+
+        public void setInitialIntervalMs(long initialIntervalMs) {
+            this.initialIntervalMs = initialIntervalMs;
+        }
+
+        public double getMultiplier() {
+            return multiplier;
+        }
+
+        public void setMultiplier(double multiplier) {
+            this.multiplier = multiplier;
+        }
+
+        public long getMaxIntervalMs() {
+            return maxIntervalMs;
+        }
+
+        public void setMaxIntervalMs(long maxIntervalMs) {
+            this.maxIntervalMs = maxIntervalMs;
+        }
+    }
+}

--- a/src/main/java/com/odysseusinc/arachne/executionengine/service/CallbackService.java
+++ b/src/main/java/com/odysseusinc/arachne/executionengine/service/CallbackService.java
@@ -27,10 +27,10 @@ import com.odysseusinc.arachne.execution_engine_common.api.v1.dto.AnalysisResult
 
 import com.odysseusinc.arachne.execution_engine_common.api.v1.dto.AnalysisResultStatusDTO;
 import java.io.File;
-import java.io.IOException;
 import java.util.Collection;
 import net.lingala.zip4j.exception.ZipException;
 import org.springframework.core.io.FileSystemResource;
+import org.springframework.http.ResponseEntity;
 
 public interface CallbackService {
     void updateAnalysisStatus(String updateURL, Long submissionId, String out, String password);
@@ -47,6 +47,6 @@ public interface CallbackService {
     void sendAnalysisResult(AnalysisRequestDTO analysis, AnalysisResultDTO analysisResult,
                             Collection<FileSystemResource> files, Long chunkSize);
 
-    void sendFailedResult(AnalysisRequestDTO analysis, Throwable e, File analysisDir,
-                          Boolean compressedResult, Long chunkSize);
+    ResponseEntity<String> sendFailedResult(AnalysisRequestDTO analysis, Throwable e, File analysisDir,
+                                            Boolean compressedResult, Long chunkSize);
 }

--- a/src/main/java/com/odysseusinc/arachne/executionengine/service/LoggingRetryListener.java
+++ b/src/main/java/com/odysseusinc/arachne/executionengine/service/LoggingRetryListener.java
@@ -1,0 +1,16 @@
+package com.odysseusinc.arachne.executionengine.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.retry.RetryCallback;
+import org.springframework.retry.RetryContext;
+import org.springframework.retry.listener.RetryListenerSupport;
+
+public class LoggingRetryListener extends RetryListenerSupport {
+    private static final Logger log = LoggerFactory.getLogger(LoggingRetryListener.class);
+
+    @Override
+    public <T, E extends Throwable> void onError(RetryContext retryContext, RetryCallback<T, E> retryCallback, Throwable throwable) {
+        log.info("The result sending is failed: [{}], retry attempt: [{}]", throwable.getMessage(), retryContext.getRetryCount());
+    }
+}

--- a/src/main/java/com/odysseusinc/arachne/executionengine/service/impl/CallbackServiceImpl.java
+++ b/src/main/java/com/odysseusinc/arachne/executionengine/service/impl/CallbackServiceImpl.java
@@ -30,14 +30,6 @@ import com.odysseusinc.arachne.execution_engine_common.api.v1.dto.AnalysisResult
 import com.odysseusinc.arachne.executionengine.aspect.FileDescriptorCount;
 import com.odysseusinc.arachne.executionengine.service.CallbackService;
 import com.odysseusinc.arachne.executionengine.util.AnalisysUtils;
-import java.io.File;
-import java.io.IOException;
-import java.util.Collection;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.concurrent.ConcurrentHashMap;
 import net.lingala.zip4j.exception.ZipException;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
@@ -51,11 +43,23 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.retry.RetryCallback;
+import org.springframework.retry.support.RetryTemplate;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 
 @Service
 public class CallbackServiceImpl implements CallbackService {
@@ -66,6 +70,8 @@ public class CallbackServiceImpl implements CallbackService {
     @Value("${submission.cleanupResults}")
     private boolean cleanupResults;
     private final RestTemplate nodeRestTemplate;
+    private final RetryTemplate successfulRetryTemplate;
+    private final RetryTemplate failureRetryTemplate;
     private static final String SENDING_STDOUT_TO_CENTRAL_LOG =
             "Sending stdout to callback for analysis with id='{}'";
     private static final String UPDATE_STATUS_FAILED_LOG = "Update analysis status id={} failed";
@@ -75,9 +81,13 @@ public class CallbackServiceImpl implements CallbackService {
     private static final String DELETE_DIR_ERROR_LOG = "Can't delete analysis directory: '{}'";
 
     @Autowired
-    public CallbackServiceImpl(@Qualifier("nodeRestTemplate") RestTemplate nodeRestTemplate) {
+    public CallbackServiceImpl(@Qualifier("nodeRestTemplate") RestTemplate nodeRestTemplate,
+                               @Qualifier("successCallbackRetryTemplate") RetryTemplate successfulRetryTemplate,
+                               @Qualifier("failureCallbackRetryTemplate") RetryTemplate failureRetryTemplate) {
 
         this.nodeRestTemplate = nodeRestTemplate;
+        this.successfulRetryTemplate = successfulRetryTemplate;
+        this.failureRetryTemplate = failureRetryTemplate;
     }
 
     @Override
@@ -121,7 +131,7 @@ public class CallbackServiceImpl implements CallbackService {
             Long chunkSize
     ) throws ZipException {
 
-        final File zipDir = com.google.common.io.Files.createTempDir();
+        final File zipDir = Files.createTempDir();
         try {
             AnalysisResultDTO result = new AnalysisResultDTO();
             result.setId(analysis.getId());
@@ -160,8 +170,44 @@ public class CallbackServiceImpl implements CallbackService {
     @FileDescriptorCount
     public void sendAnalysisResult(AnalysisRequestDTO analysis,
                                    AnalysisResultDTO analysisResult,
-                                   Collection<FileSystemResource> files, 
+                                   Collection<FileSystemResource> files,
                                    Long chunkSize) {
+        successfulRetryTemplate.execute(
+                (RetryCallback<ResponseEntity<String>, RestClientException>) retryContext -> executeSend(analysis, analysisResult, files),
+                retryContext -> sendFailedResult(analysis, retryContext.getLastThrowable(), null, false, chunkSize)
+        );
+    }
+
+    @Override
+    @FileDescriptorCount
+    public ResponseEntity<String> sendFailedResult(AnalysisRequestDTO analysis, Throwable e, File analysisDir,
+                                                   Boolean compressedResult, Long chunkSize) {
+        return failureRetryTemplate.execute(retryContext -> {
+            AnalysisResultDTO result = new AnalysisResultDTO();
+            result.setId(analysis.getId());
+            result.setStatus(AnalysisResultStatusDTO.FAILED);
+            result.setRequested(analysis.getRequested());
+            String stdout = "";
+            if (Objects.nonNull(e)) {
+                stdout = ExceptionUtils.getStackTrace(e);
+            }
+            List<FileSystemResource> resultFSResources = null;
+            try {
+                if (Objects.nonNull(analysisDir)) {
+                    resultFSResources = AnalisysUtils.getFileSystemResources(analysis, analysisDir, compressedResult, chunkSize,
+                            Files.createTempDir());
+                }
+            } catch (ZipException ex) {
+                log.error("could not collect analysis results, id={}", analysis.getId());
+                stdout += "\n" + ExceptionUtils.getStackTrace(ex);
+            }
+
+            result.setStdout(stdout);
+            return executeSend(analysis, result, resultFSResources);
+        });
+    }
+
+    private ResponseEntity<String> executeSend(AnalysisRequestDTO analysis, AnalysisResultDTO analysisResult, Collection<FileSystemResource> files) {
         HttpHeaders jsonHeader = new HttpHeaders();
         jsonHeader.setContentType(MediaType.APPLICATION_JSON);
         HttpEntity<AnalysisResultDTO> analysisRequestHttpEntity = new HttpEntity<>(analysisResult, jsonHeader);
@@ -174,49 +220,12 @@ public class CallbackServiceImpl implements CallbackService {
         headers.setContentType(MediaType.MULTIPART_FORM_DATA);
         HttpEntity<LinkedMultiValueMap<String, Object>> entity = new HttpEntity<>(multipartRequest, headers);
         Long submissionId = analysisResult.getId();
-        try {
-            nodeRestTemplate.exchange(
-                    analysis.getResultCallback(),
-                    HttpMethod.POST,
-                    entity,
-                    String.class,
-                    submissionId,
-                    analysis.getCallbackPassword());
-        } catch (RestClientException ex) {
-            log.info(SEND_RESULT_FAILED_LOG, submissionId, ex);
-            try {
-                sendFailedResult(analysis, ex, null, false, chunkSize);
-            } catch (Exception ex1) {
-                log.info(SEND_ERROR_RESULT_FAILED_LOG, submissionId, ex1);
-            }
-        }
-    }
-
-    @Override
-    @FileDescriptorCount
-    public void sendFailedResult(AnalysisRequestDTO analysis, Throwable e, File analysisDir,
-                                 Boolean compressedResult, Long chunkSize) {
-
-        AnalysisResultDTO result = new AnalysisResultDTO();
-        result.setId(analysis.getId());
-        result.setStatus(AnalysisResultStatusDTO.FAILED);
-        result.setRequested(analysis.getRequested());
-        String stdout = "";
-        if (Objects.nonNull(e)) {
-            stdout = ExceptionUtils.getStackTrace(e);
-        }
-        List<FileSystemResource> resultFSResources = null;
-        try {
-            if (Objects.nonNull(analysisDir)) {
-                resultFSResources = AnalisysUtils.getFileSystemResources(analysis, analysisDir, compressedResult, chunkSize,
-                        Files.createTempDir());
-            }
-        } catch (ZipException ex) {
-            log.error("could not collect analysis results, id={}", analysis.getId());
-            stdout += "\n" + ExceptionUtils.getStackTrace(ex);
-        }
-
-        result.setStdout(stdout);
-        sendAnalysisResult(analysis, result, resultFSResources, chunkSize);
+        return nodeRestTemplate.exchange(
+                analysis.getResultCallback(),
+                HttpMethod.POST,
+                entity,
+                String.class,
+                submissionId,
+                analysis.getCallbackPassword());
     }
 }

--- a/src/main/resources/application-base.yml
+++ b/src/main/resources/application-base.yml
@@ -98,3 +98,17 @@ bulkload:
     hadoop:
       port: 8020
       username:
+callback:
+  retry:
+    success:
+      max-attempts: 10
+      backoff-policy:
+        initial-interval-ms: 5000
+        max-interval-ms: 900000
+        multiplier: 2.71828
+    failure:
+      max-attempts: 3
+      backoff-policy:
+        initial-interval-ms: 5000
+        max-interval-ms: 30000
+        multiplier: 2.0


### PR DESCRIPTION
When result callback has failed for some reasons, it would try to retry 10 times by default. Then, if still not succeeded, try to send failure result and its reason.