### PR TITLE
In DockerEnvironmentService, Avoid NPE when rescanning for docker images. 

### DIFF
--- a/engine/src/main/java/com/odysseusinc/arachne/executionengine/config/SwaggerConfig.java
+++ b/engine/src/main/java/com/odysseusinc/arachne/executionengine/config/SwaggerConfig.java
@@ -31,10 +31,8 @@ import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
-import springfox.documentation.swagger2.annotations.EnableSwagger2;
 
 @Configuration
-@EnableSwagger2
 @ConditionalOnProperty(prefix = "swagger", name = "enable")
 public class SwaggerConfig {
 

--- a/engine/src/main/java/com/odysseusinc/arachne/executionengine/execution/r/DockerEnvironmentService.java
+++ b/engine/src/main/java/com/odysseusinc/arachne/executionengine/execution/r/DockerEnvironmentService.java
@@ -29,7 +29,7 @@ public class DockerEnvironmentService {
         try {
             List<DockerEnvironmentDTO> latest = service.listEnvironments();
             // TODO Print diff instead of simplistic size check
-            if (old == null || old.size() != latest.size()) {
+            if (old == null || (latest != null && old.size() != latest.size())) {
                 log.info("Refreshed DOCKER images ({})", latest.size());
                 latest.forEach(desc ->
                         log.info("DOCKER image [{}]: {}", desc.getImageId(), desc.getTags())


### PR DESCRIPTION
Also disable config (missed out due to recent library cleanup).